### PR TITLE
Add option to add a given SSL certificate to the trusted CAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,11 @@ Basically the script mimics the steps described in [this discourse post](https:/
 The script will stop on any error, so please be sure to skip stages, if you have already done them.
 
 You can skip some of those stages using the `-sX` arguments. Run `./setup-dev-env.sh --help` to see your options.
+
+## Adding an SSL certificate to the trusted CA's
+
+If you need MAAS to accept a self-signed SSL certificate, you must add the certificate (in PEM format) to the trusted CAs within the lxd container. You can do this with the `-c` or `--ca-crt` option, as such:
+
+```bash
+./setup-dev-env.sh --ok -c /path/to/cert.crt
+```

--- a/add-ca-cert.bash
+++ b/add-ca-cert.bash
@@ -6,9 +6,8 @@
 
 # stop execution/exit on error
 set -e
-sudo cp /home/ubuntu/* /usr/local/share/ca-certificates
 sudo update-ca-certificates
 
 # add the CN to the /etc/hosts
-hn=$(openssl x509 -noout -subject -in msm.crt -nameopt multiline | grep commonName | awk '{ print $3 }')
+hn=$(openssl x509 -noout -subject -in /usr/local/share/ca-certificates/$base_filename -nameopt multiline | grep commonName | awk '{ print $3 }')
 echo $MAAS_MANAGEMENT_IP_RANGE $hn | sudo tee --append /etc/hosts

--- a/add-ca-cert.bash
+++ b/add-ca-cert.bash
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# This script is executed inside the maas-region-controller container
+# once it is setup by setup-dev-env.sh
+#
+
+# stop execution/exit on error
+set -e
+sudo cp /home/ubuntu/* /usr/local/share/ca-certificates
+sudo update-ca-certificates
+
+# add the CN to the /etc/hosts
+hn=$(openssl x509 -noout -subject -in msm.crt -nameopt multiline | grep commonName | awk '{ print $3 }')
+echo $MAAS_MANAGEMENT_IP_RANGE $hn | sudo tee --append /etc/hosts

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -26,6 +26,8 @@ skip_lxi=0
 skip_lxd=0
 skip_lxn=0
 skip_co=0
+skip_snap=0
+crt_file=""
 
 show_help() {
   echo "Description:"
@@ -56,7 +58,9 @@ show_help() {
   echo "  -si --skip-lxi    skip initializing LXD (lxd auto init)"
   echo "  -sn --skip-lxn    skip setting up LXD profiles and networks"
   echo "  -sl --skip-lxd    skip starting the LXD container"
-  echo "  -sc --skip-checkout skip checking out the code and building the snap tree"
+  echo "  -sc --skip-checkout skip checking out the code"
+  echo "  -ss --skip-snap   skip building the snap tree"
+  echo "  -c  --ca-crt      add the given .crt (PEM format) file to the trusted CAs in the lxd container" 
   echo ""
   echo "Note:"
   echo "  If you installed maas before you likely want to run: ./$0 -su -sd -sv --ok"
@@ -107,8 +111,12 @@ setup_code() {
   fi
   echo "..done"
   echo
+}
+
+make_snap_tree() {
   echo "########################"
   echo "Setting up the snap tree"
+  cd ${maas_src}
   make snap-tree
   echo "..done"
   echo
@@ -219,6 +227,20 @@ configure_container() {
   ssh -o "StrictHostKeyChecking no" ubuntu@${container_ip} MAAS_CONTROL_IP_RANGE=${MAAS_CONTROL_IP_RANGE} MAAS_MANAGEMENT_IP_RANGE=${MAAS_MANAGEMENT_IP_RANGE} bash -s < setup-region-via-ssh.bash
 }
 
+add_ca_crt(){
+  cd ${script_dir}
+  container_ip=$(lxc list -c4 --format csv ${MAAS_CONTAINER_NAME} | grep "${control_network_prefix}"| cut -d' ' -f1)
+  echo "################################################################"
+  if ! test -f $crt_file; then
+    echo "ERROR: CA crt file does not exist."
+    exit 1
+  fi
+  echo "Copying CA crt file into container and adding it as a trusted CA"
+  # cant scp to /usr/local/share/ca-certificates because we can't ssh as root. copy to ubuntu home dir and copy over in add-ca-cert.bash script
+  scp -o "StrictHostKeyChecking no" $crt_file ubuntu@$container_ip:/home/ubuntu/
+  ssh -o "StrictHostKeyChecking no" ubuntu@${container_ip} MAAS_CONTROL_IP_RANGE=${MAAS_CONTROL_IP_RANGE} MAAS_MANAGEMENT_IP_RANGE=${MAAS_MANAGEMENT_IP_RANGE} bash -s < add-ca-cert.bash
+}
+
 run() {
   if [ ${skip_ufw} -ne 1 ]; then
     disable_ufw
@@ -247,11 +269,20 @@ run() {
   if [ ${skip_co} -ne 1 ]; then
     setup_code
   else
-    echo "Skipping code checkout and snap building"
+    echo "Skipping code checkout"
+    echo ""
+  fi
+  if [ ${skip_snap} -ne 1 ]; then
+    make_snap_tree
+  else
+    echo "Skipping making snap tree"
     echo ""
   fi
   if [ ${skip_lxd} -ne 1 ]; then
     start_container
+  fi 
+  if [ ! -z "${crt_file}" ]; then
+    add_ca_crt
   fi
   configure_container
 }
@@ -286,6 +317,13 @@ while :; do
           ;;
       -sc|--skip-checkout)
           skip_co=1
+          ;;
+      -ss|--skip-snap)
+          skip_snap=1
+          ;;
+      -c|--ca-crt)
+          crt_file=$2
+          shift
           ;;
       -?*)
           printf 'WARN: Unknown option: %s\n' "$1" >&2 # Too dangerous, exit and show help

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -236,9 +236,9 @@ add_ca_crt(){
     exit 1
   fi
   echo "Copying CA crt file into container and adding it as a trusted CA"
-  # cant scp to /usr/local/share/ca-certificates because we can't ssh as root. copy to ubuntu home dir and copy over in add-ca-cert.bash script
-  scp -o "StrictHostKeyChecking no" $crt_file ubuntu@$container_ip:/home/ubuntu/
-  ssh -o "StrictHostKeyChecking no" ubuntu@${container_ip} MAAS_CONTROL_IP_RANGE=${MAAS_CONTROL_IP_RANGE} MAAS_MANAGEMENT_IP_RANGE=${MAAS_MANAGEMENT_IP_RANGE} bash -s < add-ca-cert.bash
+  base_filename=$(basename $crt_file)
+  lxc file push $crt_file $MAAS_CONTAINER_NAME/usr/local/share/ca-certificates/$base_filename
+  ssh -o "StrictHostKeyChecking no" ubuntu@${container_ip} MAAS_CONTROL_IP_RANGE=${MAAS_CONTROL_IP_RANGE} MAAS_MANAGEMENT_IP_RANGE=${MAAS_MANAGEMENT_IP_RANGE} base_filename=${base_filename} bash -s < add-ca-cert.bash $base_filename
 }
 
 run() {


### PR DESCRIPTION
If MAAS needs to trust a self-signed TLS certificate, this allows you to provide such a certificate so that it can be configured as trusted (for use in dev TLS setup in MSM)