### PR TITLE
fix IPv6 network string manipulation and pass IPv6 vars to ssh env

### DIFF
--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -260,7 +260,13 @@ configure_container() {
   echo "################################################################"
   echo "SSHing into ${MAAS_CONTAINER_NAME} (${container_ip}) development and setting it up"
   # could pass vars in there with ssh ubuntu@${container_ip} 'bash -s' < setup-region-via-ssh.sh var1 var2 ...
-  ssh -o "StrictHostKeyChecking no" ubuntu@${container_ip} MAAS_CONTROL_IP_RANGE=${MAAS_CONTROL_IP_RANGE} MAAS_MANAGEMENT_IP_RANGE=${MAAS_MANAGEMENT_IP_RANGE} bash -s < setup-region-via-ssh.bash
+  ssh -o "StrictHostKeyChecking no" ubuntu@${container_ip}\
+      MAAS_CONTROL_IP_RANGE=${MAAS_CONTROL_IP_RANGE}\
+      MAAS_MANAGEMENT_IP_RANGE=${MAAS_MANAGEMENT_IP_RANGE}\
+      MAAS_IPV6_IP_RANGE=${MAAS_IPV6_IP_RANGE}\
+      MAAS_DUAL_STACK_IPV4_RANGE=${MAAS_DUAL_STACK_IPV4_RANGE}\
+      MAAS_DUAL_STACK_IPV6_RANGE=${MAAS_DUAL_STACK_IPV6_RANGE}\
+      bash -s < setup-region-via-ssh.bash
 }
 
 add_ca_crt(){
@@ -274,7 +280,14 @@ add_ca_crt(){
   echo "Copying CA crt file into container and adding it as a trusted CA"
   base_filename=$(basename $crt_file)
   lxc file push $crt_file $MAAS_CONTAINER_NAME/usr/local/share/ca-certificates/$base_filename
-  ssh -o "StrictHostKeyChecking no" ubuntu@${container_ip} MAAS_CONTROL_IP_RANGE=${MAAS_CONTROL_IP_RANGE} MAAS_MANAGEMENT_IP_RANGE=${MAAS_MANAGEMENT_IP_RANGE} base_filename=${base_filename} bash -s < add-ca-cert.bash $base_filename
+  ssh -o "StrictHostKeyChecking no" ubuntu@${container_ip}\
+      MAAS_CONTROL_IP_RANGE=${MAAS_CONTROL_IP_RANGE}\
+      MAAS_MANAGEMENT_IP_RANGE=${MAAS_MANAGEMENT_IP_RANGE}\
+      MAAS_IPV6_IP_RANGE=${MAAS_IPV6_IP_RANGE}\
+      MAAS_DUAL_STACK_IPV4_RANGE=${MAAS_DUAL_STACK_IPV4_RANGE}\
+      MAAS_DUAL_STACK_IPV6_RANGE=${MAAS_DUAL_STACK_IPV6_RANGE}\
+      base_filename=${base_filename}\
+      bash -s < add-ca-cert.bash $base_filename
 }
 
 run() {

--- a/setup-region-via-ssh.bash
+++ b/setup-region-via-ssh.bash
@@ -11,9 +11,9 @@ container_ip=$(hostname -I | cut -d' ' -f1)
 gateway_ip=$(hostname -I | cut -d' ' -f1)
 control_network_prefix=${MAAS_CONTROL_IP_RANGE%.*}
 kvm_network_prefix=${MAAS_MANAGEMENT_IP_RANGE%.*}
-ipv6_network_prefix=${MAAS_IPV6_IP_RANGE%.*}
+ipv6_network_prefix=${MAAS_IPV6_IP_RANGE%:*}
 dual_stack_ipv4_prefix=${MAAS_DUAL_STACK_IPV4_RANGE%.*}
-dual_stack_ipv6_prefix=${MAAS_DUAL_STACK_IPV6_RANGE%.*}
+dual_stack_ipv6_prefix=${MAAS_DUAL_STACK_IPV6_RANGE%:*}
 
 echo "${container_ip} ${gateway_ip} ${control_network_prefix} ${kvm_network_prefix} ${ipv6_network_prefix} ${dual_stack_ipv4_prefix} ${dual_stack_ipv6_prefix}"
 


### PR DESCRIPTION
fixes a copy+paste issue that was expecting a V4 address for a V6 variable, i.e s/./:, and passes the V6 variables into the ssh env.