### PR TITLE
Fix/error at admin login

### DIFF
--- a/setup-region-via-ssh.bash
+++ b/setup-region-via-ssh.bash
@@ -92,7 +92,7 @@ echo "###########################"
 echo "Login using admin profile"
 declare -i maas_up=1
 while [ $maas_up -ne 0 ]; do
-  # Check if the MAAS API is up before attemtping to
+  # Check if the MAAS API is up before attempting to login
   if curl -sf "http://${container_ip}:5240/MAAS/api/2.0/version/" > /dev/null 2>&1; then
     maas login admin "http://${container_ip}:5240/MAAS/api/2.0/" $(sudo maas apikey --username=maas);
     maas_up=$?

--- a/setup-region-via-ssh.bash
+++ b/setup-region-via-ssh.bash
@@ -92,9 +92,11 @@ echo "###########################"
 echo "Login using admin profile"
 declare -i maas_up=1
 while [ $maas_up -ne 0 ]; do
-  maas login admin "http://${container_ip}:5240/MAAS/api/2.0/" $(sudo maas apikey --username=maas);
-  maas_up=$?
-  if [ $maas_up -ne 0 ]; then
+  # Check if the MAAS API is up before attemtping to
+  if curl -sf "http://${container_ip}:5240/MAAS/api/2.0/version/" > /dev/null 2>&1; then
+    maas login admin "http://${container_ip}:5240/MAAS/api/2.0/" $(sudo maas apikey --username=maas);
+    maas_up=$?
+  else 
     echo "Retrying in 5 seconds..."
     sleep 5
   fi


### PR DESCRIPTION
fix: Add MAAS api is ready check before login

- Fix the 502 error and exit that occurs during every setup I get during this stage in the script.
- This actively checks the MAAS api is up before attempting to connect.
- Tested on 24.04.1 LTS