### PR TITLE
fix: Remove nginx

### DIFF
--- a/setup-region-via-ssh.bash
+++ b/setup-region-via-ssh.bash
@@ -46,9 +46,9 @@ sudo netplan apply
 
 echo
 echo "############################################"
-echo "Disabling postgres, nginx and dhcp services."
-sudo systemctl stop named postgresql nginx isc-dhcp-server
-sudo systemctl disable named postgresql nginx isc-dhcp-server
+echo "Disabling postgres and dhcp services."
+sudo systemctl stop named postgresql isc-dhcp-server
+sudo systemctl disable named postgresql isc-dhcp-server
 
 echo
 echo "#################################"


### PR DESCRIPTION
Brings setup script in line with [this PR](https://github.com/canonical/maas/commit/ab68c2d7d0847692510a7d29b06e0deeb26dc37a)

Since that PR, when I try to run maas-dev-setup, it would fail in-container when trying to stop the nginx service. This is because `make install-dependencies` wouldn't install nginx as it was removed from the base package list.

This commit fixes this and allows setup to proceed.