### PR TITLE
feat: add linux tool packages to install script

### DIFF
--- a/setup-region-via-ssh.bash
+++ b/setup-region-via-ssh.bash
@@ -20,7 +20,7 @@ echo "${container_ip} ${gateway_ip} ${control_network_prefix} ${kvm_network_pref
 echo
 echo "######################################"
 echo "Installing make and MAAS dependencies."
-sudo apt-get install make
+sudo apt-get install make linux-tools-$(uname -r) linux-cloud-tools-$(uname -r) -y
 cd /work
 make install-dependencies
 


### PR DESCRIPTION
given this is using a container, the version installed from `linux-tools-common` (coming from `make install-dependencies`) might not match the running kernel, this then breaks the `bpftool` step in building the maas-agent. In order to fix this, we can install `linux-tools-$(uname -r)`, ensuring the version for the target kernel is available.