### PR TITLE
Add config to install MAAS Release Version

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -8,6 +8,11 @@
 # These are currently noble for 3.6+, jammy for 3.4, 3.5
 UBUNTU_VERSION="noble"
 
+# Rather than setting up the dev environment,
+# you can also specify a release version to install.
+# For example 3.5/stable
+MAAS_RELEASE_VERSION=""
+
 # This assumes that your maas source should be installed next to this project, e.g.
 # $HOME/src/setup-maas-dev-env/ --> $HOME/src/maas/
 MAAS_SRC="../maas"

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -266,6 +266,7 @@ configure_container() {
       MAAS_IPV6_IP_RANGE=${MAAS_IPV6_IP_RANGE}\
       MAAS_DUAL_STACK_IPV4_RANGE=${MAAS_DUAL_STACK_IPV4_RANGE}\
       MAAS_DUAL_STACK_IPV6_RANGE=${MAAS_DUAL_STACK_IPV6_RANGE}\
+      MAAS_RELEASE_VERSION=${MAAS_RELEASE_VERSION}\
       bash -s < setup-region-via-ssh.bash
 }
 

--- a/setup-region-via-ssh.bash
+++ b/setup-region-via-ssh.bash
@@ -14,8 +14,9 @@ kvm_network_prefix=${MAAS_MANAGEMENT_IP_RANGE%.*}
 ipv6_network_prefix=${MAAS_IPV6_IP_RANGE%:*}
 dual_stack_ipv4_prefix=${MAAS_DUAL_STACK_IPV4_RANGE%.*}
 dual_stack_ipv6_prefix=${MAAS_DUAL_STACK_IPV6_RANGE%:*}
+maas_release_version=${MAAS_RELEASE_VERSION}
 
-echo "${container_ip} ${gateway_ip} ${control_network_prefix} ${kvm_network_prefix} ${ipv6_network_prefix} ${dual_stack_ipv4_prefix} ${dual_stack_ipv6_prefix}"
+echo "${container_ip} ${gateway_ip} ${control_network_prefix} ${kvm_network_prefix} ${ipv6_network_prefix} ${dual_stack_ipv4_prefix} ${dual_stack_ipv6_prefix} ${maas_release_version}"
 
 echo
 echo "######################################"
@@ -54,27 +55,39 @@ sudo systemctl disable named postgresql isc-dhcp-server
 # https://github.com/canonical/maas/commit/ab68c2d7d0847692510a7d29b06e0deeb26dc37a
 dpkg --list | grep nginx-core && sudo systemctl stop nginx && systemctl disable nginx
 
-echo
-echo "#################################"
-echo "Installing the MAAS test database"
-sudo snap install maas-test-db --channel=latest/edge
+  if [ ${maas_release_version} != "" ]; then
+    echo
+    echo "#################################"
+    echo "Installing MAAS ${maas_release_version}"
+    sudo snap install maas --channel=${maas_release_version}
 
-echo
-echo "#######################"
-echo "Unpacking the snap tree"
-sudo snap try dev-snap/tree
+    echo
+    echo "#################################"
+    echo "Installing the MAAS test database"
+    sudo snap install maas-test-db --channel=${maas_release_version}
+  else
+    echo
+    echo "#################################"
+    echo "Installing the MAAS test database"
+    sudo snap install maas-test-db --channel=latest/edge
 
-echo
-echo "##########################"
-echo "Connecting snap interfaces"
-./utilities/connect-snap-interfaces
+    echo
+    echo "#######################"
+    echo "Unpacking the snap tree"
+    sudo snap try dev-snap/tree
 
-echo
-echo "####################################"
-echo "Installing and running the MAAS snap"
-make
-make snap-tree-sync
-sudo snap restart maas
+    echo
+    echo "##########################"
+    echo "Connecting snap interfaces"
+    ./utilities/connect-snap-interfaces
+
+    echo
+    echo "####################################"
+    echo "Installing and running the MAAS snap"
+    make
+    make snap-tree-sync
+    sudo snap restart maas
+  fi
 
 echo
 echo "#######################"


### PR DESCRIPTION
## Why/What?
Adds an optional `MAAS_RELEASE_VERSION` to `config.sh` which can be set to any release candidate, i.e. `3.5/stable`.
Assuming an existing dev environment, this allows a user to simply do:
```
> lxc delete maas-dev --force
> /setup-dev-env.sh -su -sd -si -sn -sc -ss --ok
```
This is the alternative to manually having to do 
``` 
> lxc launch ubuntu:24.04 other-maas-dev-container -p default -p maas-dev
> # all the other dhcp, user account, setup here
```
This allows quick comparison of MAAS behavior on existing releases.

## Note
- tested only for 3.5 and 3.6