### PR TITLE
Allow multiple setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,28 @@ that the following names/network ranges are not yet used by LXD (or change value
 `config.sh`).
 
 * a profile in LXDs default project called `$MAAS_CONTAINER_NAME`
-* two networks named `maas-ctrl` and `maas-kvm`
-  * these networks will use the IP ranges `$MAAS_CONTROL_IP_RANGE` and `MAAS_MANAGEMENT_IP_RANGE`
+* four networks named after `$MAAS_CTRL_NETWORK`, `$MAAS_KVM_NETWORK`, `$MAAS_IPV6_NETWORK`, and `$MAAS_DUAL_STACK_NETWORK`
+  * these networks will use the IP ranges `$MAAS_CONTROL_IP_RANGE`, `$MAAS_MANAGEMENT_IP_RANGE`, and the IPv6/dual-stack ranges
+
+
+## Running multiple MAAS versions simultaneously
+
+Each MAAS version gets its own isolated set of LXD resources. Set `MAAS_INSTANCE` in
+`config.sh` to a short unique identifier (max 5 characters) before running the script.
+All container, profile, and network names are derived from it.
+
+You also **must** assign different IP ranges per instance to avoid subnet conflicts.
+Use the skip flags (`-su -sd -si`) to skip one-time steps when setting up additional instances:
+
+```sh
+# First instance (e.g. MAAS 3.6)
+# In config.sh: MAAS_INSTANCE="36", MAAS_CONTROL_IP_RANGE="10.10.36.1", MAAS_MANAGEMENT_IP_RANGE="10.20.36.1"
+./setup-dev-env.sh --ok
+
+# Second instance (e.g. MAAS 3.7)
+# In config.sh: MAAS_INSTANCE="37", MAAS_CONTROL_IP_RANGE="10.10.37.1", MAAS_MANAGEMENT_IP_RANGE="10.20.37.1"
+./setup-dev-env.sh --ok -su -sd -si
+```
 
 
 ## How to run this script?

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ that the following names/network ranges are not yet used by LXD (or change value
 ## Running multiple MAAS versions simultaneously
 
 Each MAAS version gets its own isolated set of LXD resources. Set `MAAS_INSTANCE` in
-`config.sh` to a short unique identifier (max 5 characters) before running the script.
+`config.sh` to the numeric MAAS version string (max 5 digits, e.g. `"38"` for MAAS 3.8).
 All container, profile, network names, IP ranges, **and source directory** are derived from it automatically.
 
 Each instance clones MAAS into a separate directory (`../maas-<INSTANCE>`), so their

--- a/README.md
+++ b/README.md
@@ -33,18 +33,21 @@ that the following names/network ranges are not yet used by LXD (or change value
 
 Each MAAS version gets its own isolated set of LXD resources. Set `MAAS_INSTANCE` in
 `config.sh` to a short unique identifier (max 5 characters) before running the script.
-All container, profile, and network names are derived from it.
+All container, profile, network names, IP ranges, **and source directory** are derived from it automatically.
 
-You also **must** assign different IP ranges per instance to avoid subnet conflicts.
+Each instance clones MAAS into a separate directory (`../maas-<INSTANCE>`), so their
+snap trees never conflict. IP ranges are also derived automatically — no manual range
+assignment needed.
+
 Use the skip flags (`-su -sd -si`) to skip one-time steps when setting up additional instances:
 
 ```sh
-# First instance (e.g. MAAS 3.6)
-# In config.sh: MAAS_INSTANCE="36", MAAS_CONTROL_IP_RANGE="10.10.36.1", MAAS_MANAGEMENT_IP_RANGE="10.20.36.1"
+# First instance (e.g. MAAS 3.6) — clone goes to ../maas-36
+# In config.sh: MAAS_INSTANCE="36"
 ./setup-dev-env.sh --ok
 
-# Second instance (e.g. MAAS 3.7)
-# In config.sh: MAAS_INSTANCE="37", MAAS_CONTROL_IP_RANGE="10.10.37.1", MAAS_MANAGEMENT_IP_RANGE="10.20.37.1"
+# Second instance (e.g. MAAS 3.8) — clone goes to ../maas-38
+# In config.sh: MAAS_INSTANCE="38"
 ./setup-dev-env.sh --ok -su -sd -si
 ```
 
@@ -68,7 +71,7 @@ do the following:
 * remove everything from LXD (e.g. containers, profiles, networks, ...) for all projects
   * you can use [LXD Delete All](https://github.com/tmerten/lxd-delete-all) for this job
 * remove your [libvirt](https://libvirt.org/) network definitions (`virsh net-destroy` and `virsh net-undefine` for all networks)
-* delete (or move) your current maas source code
+* delete (or move) your MAAS source code (e.g. `../maas-<INSTANCE>`)
 
 ## What happens if I run this script?
 

--- a/config.sh
+++ b/config.sh
@@ -4,24 +4,34 @@
 
 # Instance name used to namespace all LXD resources (container, profile, networks, VM host).
 # This allows running multiple MAAS versions side by side without conflicts.
-# Must be a numeric MAAS version string, max 5 digits (kernel bridge name limit of 15 chars).
-# Examples: "36" for MAAS 3.6, "38" for MAAS 3.8, "310" for MAAS 3.10.
-MAAS_INSTANCE="38"
+# Must be a numeric MAAS version string, max 5 digits (kernel bridge name limit of 15 chars),
+# or the special value "latest" which uses no suffix and the base IP ranges (x.x.0.x).
+# Examples: "36" for MAAS 3.6, "38" for MAAS 3.8, "310" for MAAS 3.10, "latest" for tip.
+MAAS_INSTANCE="latest"
 
 # Depending on the MAAS version, that you are running,
 # you should pick the appropriate ubuntu version.
 #
 # These are currently noble for 3.6+, jammy for 3.4, 3.5
-UBUNTU_VERSION="noble"
+UBUNTU_VERSION="resolute"
+
+# "latest" uses no suffix so all names are unqualified (e.g. "maas", "maas-ctrl").
+# All other instances append "-<MAAS_INSTANCE>" to avoid conflicts.
+if [ "${MAAS_INSTANCE}" = "latest" ]; then
+  _instance_suffix=""
+else
+  _instance_suffix="-${MAAS_INSTANCE}"
+fi
 
 # This assumes that your maas source is installed next to this project,
-# in a directory named after the instance (e.g. ../maas-38 for MAAS_INSTANCE="38").
+# in a directory named after the instance (e.g. ../maas-38 for MAAS_INSTANCE="38",
+# or ../maas for MAAS_INSTANCE="latest").
 # Each instance needs its own checkout so their snap trees don't clobber each other.
-MAAS_SRC="../maas-${MAAS_INSTANCE}"
+MAAS_SRC="../maas${_instance_suffix}"
 
 # This is the name of container MAAS will be running in
 # as well as the name for the related LXD profile
-MAAS_CONTAINER_NAME="maas-${MAAS_INSTANCE}"
+MAAS_CONTAINER_NAME="maas${_instance_suffix}"
 
 # If you enter a launchpad-id, the script can automatically setup your local fork
 # and retrieve your public ssh key from launchpad
@@ -33,23 +43,26 @@ MAAS_LAUNCHPAD_ID="aloiziomacedo"
 
 # LXD network names — derived from MAAS_INSTANCE to avoid conflicts between versions.
 # Shortened base names keep the resulting bridge interface name under the 15-char kernel limit.
-MAAS_CTRL_NETWORK="maas-ctrl-${MAAS_INSTANCE}"
-MAAS_KVM_NETWORK="maas-kvm-${MAAS_INSTANCE}"
-MAAS_IPV6_NETWORK="maas-ip6-${MAAS_INSTANCE}"
-MAAS_DUAL_STACK_NETWORK="maas-ds-${MAAS_INSTANCE}"
+MAAS_CTRL_NETWORK="maas-ctrl${_instance_suffix}"
+MAAS_KVM_NETWORK="maas-kvm${_instance_suffix}"
+MAAS_IPV6_NETWORK="maas-ip6${_instance_suffix}"
+MAAS_DUAL_STACK_NETWORK="maas-ds${_instance_suffix}"
 
 # IP ranges are automatically derived from MAAS_INSTANCE so that different instances
 # do not conflict with each other.
 #
-# MAAS_INSTANCE must be a numeric MAAS version string (e.g. "36", "38", "310", "40").
-# The third IPv4 octet is computed as: major * 30 + minor, where the first digit is
-# the major version and the remaining digits are the minor version.
+# "latest" uses octet 0 (base ranges: 10.10.0.x, 10.20.0.x, etc.).
+# Numeric instances use: major * 30 + minor as the third IPv4 octet, where the first
+# digit is the major version and the remaining digits are the minor version.
 # Examples: "36" → 3*30+6 = 96,  "310" → 3*30+10 = 100,  "40" → 4*30+0 = 120.
 #
 # To override any range, set the variable explicitly after this block.
 case "${MAAS_INSTANCE}" in
+latest)
+  _instance_octet=0
+  ;;
 *[!0-9]*)
-  echo "ERROR: MAAS_INSTANCE must be a numeric MAAS version string (e.g. \"36\", \"38\", \"310\")."
+  echo "ERROR: MAAS_INSTANCE must be a numeric MAAS version string (e.g. \"36\", \"38\", \"310\") or \"latest\"."
   echo "  Got: '${MAAS_INSTANCE}'"
   exit 1
   ;;
@@ -60,8 +73,8 @@ case "${MAAS_INSTANCE}" in
   _instance_octet=$((_major * 30 + _minor))
   ;;
 esac
-if [ "${_instance_octet}" -lt 1 ] || [ "${_instance_octet}" -gt 253 ]; then
-  echo "ERROR: derived IP octet ${_instance_octet} for MAAS_INSTANCE='${MAAS_INSTANCE}' is out of range [1, 253]."
+if [ "${_instance_octet}" -gt 253 ]; then
+  echo "ERROR: derived IP octet ${_instance_octet} for MAAS_INSTANCE='${MAAS_INSTANCE}' is out of range [0, 253]."
   echo "  Choose a different MAAS_INSTANCE value."
   exit 1
 fi

--- a/config.sh
+++ b/config.sh
@@ -14,8 +14,10 @@ MAAS_INSTANCE="dev"
 # These are currently noble for 3.6+, jammy for 3.4, 3.5
 UBUNTU_VERSION="noble"
 
-# This assumes that your maas source should be installed next to this project.
-MAAS_SRC="../maas"
+# This assumes that your maas source is installed next to this project,
+# in a directory named after the instance (e.g. ../maas-38 for MAAS_INSTANCE="38").
+# Each instance needs its own checkout so their snap trees don't clobber each other.
+MAAS_SRC="../maas-${MAAS_INSTANCE}"
 
 # This is the name of container MAAS will be running in
 # as well as the name for the related LXD profile

--- a/config.sh
+++ b/config.sh
@@ -2,19 +2,24 @@
 # Configuration variables for setup-dev-env-.sh
 #
 
+# Instance name used to namespace all LXD resources (container, profile, networks, VM host).
+# This allows running multiple MAAS versions side by side without conflicts.
+# Must be at most 5 alphanumeric/hyphen characters (kernel bridge name limit of 15 chars).
+# Examples: "36" for MAAS 3.6, "37" for MAAS 3.7, "main" for main branch.
+MAAS_INSTANCE="dev"
+
 # Depending on the MAAS version, that you are running,
 # you should pick the appropriate ubuntu version.
 #
 # These are currently noble for 3.6+, jammy for 3.4, 3.5
 UBUNTU_VERSION="noble"
 
-# This assumes that your maas source should be installed next to this project, e.g.
-# $HOME/src/setup-maas-dev-env/ --> $HOME/src/maas/
+# This assumes that your maas source should be installed next to this project.
 MAAS_SRC="../maas"
 
 # This is the name of container MAAS will be running in
 # as well as the name for the related LXD profile
-MAAS_CONTAINER_NAME="maas-dev"
+MAAS_CONTAINER_NAME="maas-${MAAS_INSTANCE}"
 
 # If you enter a launchpad-id, the script can automatically setup your local fork
 # and retrieve your public ssh key from launchpad
@@ -24,15 +29,19 @@ MAAS_LAUNCHPAD_ID=""
 # Leave empty or set to "default" to use the default project
 # MAAS_LXD_PROJECT="maas-dev"
 
-# The netmasks for the LXD networks you would like to use
+# LXD network names — derived from MAAS_INSTANCE to avoid conflicts between versions.
+# Shortened base names keep the resulting bridge interface name under the 15-char kernel limit.
+MAAS_CTRL_NETWORK="maas-ctrl-${MAAS_INSTANCE}"
+MAAS_KVM_NETWORK="maas-kvm-${MAAS_INSTANCE}"
+MAAS_IPV6_NETWORK="maas-ip6-${MAAS_INSTANCE}"
+MAAS_DUAL_STACK_NETWORK="maas-ds-${MAAS_INSTANCE}"
+
+# The netmasks for the LXD networks you would like to use.
 # Note:
 #   netmasks will be set to /24 and IP_RANGEs have to end with .1 / ::1
-MAAS_CONTROL_NETWORK="maas-dev"
+#   Each instance MUST use different IP ranges to avoid subnet conflicts.
 MAAS_CONTROL_IP_RANGE="10.10.0.1"
-MAAS_MANAGEMENT_NETWORK="maas-dev"
 MAAS_MANAGEMENT_IP_RANGE="10.20.0.1"
-MAAS_IPV6_NETWORK="maas-ipv6"
 MAAS_IPV6_IP_RANGE="fd42:be3f:b08a:3d6c::1"
-MAAS_DUAL_STACK_NETWORK="maas-dual-stack"
 MAAS_DUAL_STACK_IPV4_RANGE="10.30.0.1"
 MAAS_DUAL_STACK_IPV6_RANGE="fd42:be3f:b08b:3d6d::1"

--- a/config.sh
+++ b/config.sh
@@ -11,9 +11,9 @@ MAAS_INSTANCE="latest"
 
 # Ubuntu version is derived from MAAS_INSTANCE. Override here if needed.
 case "${MAAS_INSTANCE}" in
-  latest|38) UBUNTU_VERSION="resolute" ;;
-  36|37)     UBUNTU_VERSION="noble"    ;;
-  *)         UBUNTU_VERSION="resolute" ;;
+latest | 38) UBUNTU_VERSION="resolute" ;;
+36 | 37) UBUNTU_VERSION="noble" ;;
+*) UBUNTU_VERSION="resolute" ;;
 esac
 
 # "latest" uses no suffix so all names are unqualified (e.g. "maas", "maas-ctrl").
@@ -32,7 +32,7 @@ MAAS_SRC="../maas${_instance_suffix}"
 
 # This is the name of container MAAS will be running in
 # as well as the name for the related LXD profile
-MAAS_CONTAINER_NAME="maas${_instance_suffix}"
+MAAS_CONTAINER_NAME="maas-dev${_instance_suffix}"
 
 # If you enter a launchpad-id, the script can automatically setup your local fork
 # and retrieve your public ssh key from launchpad

--- a/config.sh
+++ b/config.sh
@@ -6,7 +6,7 @@
 # This allows running multiple MAAS versions side by side without conflicts.
 # Must be a numeric MAAS version string, max 5 digits (kernel bridge name limit of 15 chars).
 # Examples: "36" for MAAS 3.6, "38" for MAAS 3.8, "310" for MAAS 3.10.
-MAAS_INSTANCE="37"
+MAAS_INSTANCE="38"
 
 # Depending on the MAAS version, that you are running,
 # you should pick the appropriate ubuntu version.
@@ -25,7 +25,7 @@ MAAS_CONTAINER_NAME="maas-${MAAS_INSTANCE}"
 
 # If you enter a launchpad-id, the script can automatically setup your local fork
 # and retrieve your public ssh key from launchpad
-MAAS_LAUNCHPAD_ID=""
+MAAS_LAUNCHPAD_ID="aloiziomacedo"
 
 # The LXD project in which this installation should reside
 # Leave empty or set to "default" to use the default project

--- a/config.sh
+++ b/config.sh
@@ -4,9 +4,9 @@
 
 # Instance name used to namespace all LXD resources (container, profile, networks, VM host).
 # This allows running multiple MAAS versions side by side without conflicts.
-# Must be at most 5 alphanumeric/hyphen characters (kernel bridge name limit of 15 chars).
-# Examples: "36" for MAAS 3.6, "37" for MAAS 3.7, "main" for main branch.
-MAAS_INSTANCE="dev"
+# Must be a numeric MAAS version string, max 5 digits (kernel bridge name limit of 15 chars).
+# Examples: "36" for MAAS 3.6, "38" for MAAS 3.8, "310" for MAAS 3.10.
+MAAS_INSTANCE="37"
 
 # Depending on the MAAS version, that you are running,
 # you should pick the appropriate ubuntu version.
@@ -41,22 +41,17 @@ MAAS_DUAL_STACK_NETWORK="maas-ds-${MAAS_INSTANCE}"
 # IP ranges are automatically derived from MAAS_INSTANCE so that different instances
 # do not conflict with each other.
 #
-# Derivation rules for the third IPv4 octet:
-#   - Numeric MAAS_INSTANCE (e.g. a MAAS version like "36", "310", "40"):
-#       Split into the first digit (major) and the remaining digits (minor).
-#       Octet = major * 30 + minor  (treats the version as a pair of base 30 digits).
-#       Examples: "36" → 3*30+6 = 96,  "310" → 3*30+10 = 100,  "40" → 4*30+0 = 120.
-#       This keeps different major versions well-separated and is future-proof as
-#       minor versions grow beyond 9.
-#   - Non-numeric MAAS_INSTANCE (e.g. "main", "dev"):
-#       A deterministic cksum hash maps it to [1, 253].
-#       Note: hash-based derivation is best-effort; two distinct non-numeric instances
-#       may collide. Prefer numeric (version-style) instance names when possible.
+# MAAS_INSTANCE must be a numeric MAAS version string (e.g. "36", "38", "310", "40").
+# The third IPv4 octet is computed as: major * 30 + minor, where the first digit is
+# the major version and the remaining digits are the minor version.
+# Examples: "36" → 3*30+6 = 96,  "310" → 3*30+10 = 100,  "40" → 4*30+0 = 120.
 #
 # To override any range, set the variable explicitly after this block.
 case "${MAAS_INSTANCE}" in
 *[!0-9]*)
-  _instance_octet=$(printf '%s' "${MAAS_INSTANCE}" | cksum | awk '{print ($1 % 253) + 1}')
+  echo "ERROR: MAAS_INSTANCE must be a numeric MAAS version string (e.g. \"36\", \"38\", \"310\")."
+  echo "  Got: '${MAAS_INSTANCE}'"
+  exit 1
   ;;
 *)
   _major="${MAAS_INSTANCE%"${MAAS_INSTANCE#?}"}" # first character (major version digit)

--- a/config.sh
+++ b/config.sh
@@ -81,6 +81,12 @@ if [ "${_instance_octet}" -gt 253 ]; then
 fi
 _instance_hex=$(printf '%04x' "${_instance_octet}")
 
+# maas-test-db snap channel derived from MAAS_INSTANCE.
+case "${MAAS_INSTANCE}" in
+  latest) MAAS_TEST_DB_CHANNEL="latest/edge" ;;
+  *)      MAAS_TEST_DB_CHANNEL="${_major}.${_minor}/edge" ;;
+esac
+
 # Note: netmasks will be set to /24 (IPv4) or /64 (IPv6); IP_RANGEs must end with .1 / ::1.
 MAAS_CONTROL_IP_RANGE="10.10.${_instance_octet}.1"
 MAAS_MANAGEMENT_IP_RANGE="10.20.${_instance_octet}.1"

--- a/config.sh
+++ b/config.sh
@@ -36,12 +36,43 @@ MAAS_KVM_NETWORK="maas-kvm-${MAAS_INSTANCE}"
 MAAS_IPV6_NETWORK="maas-ip6-${MAAS_INSTANCE}"
 MAAS_DUAL_STACK_NETWORK="maas-ds-${MAAS_INSTANCE}"
 
-# The netmasks for the LXD networks you would like to use.
-# Note:
-#   netmasks will be set to /24 and IP_RANGEs have to end with .1 / ::1
-#   Each instance MUST use different IP ranges to avoid subnet conflicts.
-MAAS_CONTROL_IP_RANGE="10.10.0.1"
-MAAS_MANAGEMENT_IP_RANGE="10.20.0.1"
-MAAS_IPV6_IP_RANGE="fd42:be3f:b08a:3d6c::1"
-MAAS_DUAL_STACK_IPV4_RANGE="10.30.0.1"
-MAAS_DUAL_STACK_IPV6_RANGE="fd42:be3f:b08b:3d6d::1"
+# IP ranges are automatically derived from MAAS_INSTANCE so that different instances
+# do not conflict with each other.
+#
+# Derivation rules for the third IPv4 octet:
+#   - Numeric MAAS_INSTANCE (e.g. a MAAS version like "36", "310", "40"):
+#       Split into the first digit (major) and the remaining digits (minor).
+#       Octet = major * 30 + minor  (treats the version as a pair of base 30 digits).
+#       Examples: "36" → 3*30+6 = 96,  "310" → 3*30+10 = 100,  "40" → 4*30+0 = 120.
+#       This keeps different major versions well-separated and is future-proof as
+#       minor versions grow beyond 9.
+#   - Non-numeric MAAS_INSTANCE (e.g. "main", "dev"):
+#       A deterministic cksum hash maps it to [1, 253].
+#       Note: hash-based derivation is best-effort; two distinct non-numeric instances
+#       may collide. Prefer numeric (version-style) instance names when possible.
+#
+# To override any range, set the variable explicitly after this block.
+case "${MAAS_INSTANCE}" in
+*[!0-9]*)
+  _instance_octet=$(printf '%s' "${MAAS_INSTANCE}" | cksum | awk '{print ($1 % 253) + 1}')
+  ;;
+*)
+  _major="${MAAS_INSTANCE%"${MAAS_INSTANCE#?}"}" # first character (major version digit)
+  _minor="${MAAS_INSTANCE#?}"                    # remaining characters (minor version)
+  : "${_minor:=0}"
+  _instance_octet=$((_major * 30 + _minor))
+  ;;
+esac
+if [ "${_instance_octet}" -lt 1 ] || [ "${_instance_octet}" -gt 253 ]; then
+  echo "ERROR: derived IP octet ${_instance_octet} for MAAS_INSTANCE='${MAAS_INSTANCE}' is out of range [1, 253]."
+  echo "  Choose a different MAAS_INSTANCE value."
+  exit 1
+fi
+_instance_hex=$(printf '%04x' "${_instance_octet}")
+
+# Note: netmasks will be set to /24 (IPv4) or /64 (IPv6); IP_RANGEs must end with .1 / ::1.
+MAAS_CONTROL_IP_RANGE="10.10.${_instance_octet}.1"
+MAAS_MANAGEMENT_IP_RANGE="10.20.${_instance_octet}.1"
+MAAS_IPV6_IP_RANGE="fd42:${_instance_hex}:b08a:3d6c::1"
+MAAS_DUAL_STACK_IPV4_RANGE="10.30.${_instance_octet}.1"
+MAAS_DUAL_STACK_IPV6_RANGE="fd42:${_instance_hex}:b08b:3d6d::1"

--- a/config.sh
+++ b/config.sh
@@ -9,11 +9,12 @@
 # Examples: "36" for MAAS 3.6, "38" for MAAS 3.8, "310" for MAAS 3.10, "latest" for tip.
 MAAS_INSTANCE="latest"
 
-# Depending on the MAAS version, that you are running,
-# you should pick the appropriate ubuntu version.
-#
-# These are currently noble for 3.6+, jammy for 3.4, 3.5
-UBUNTU_VERSION="resolute"
+# Ubuntu version is derived from MAAS_INSTANCE. Override here if needed.
+case "${MAAS_INSTANCE}" in
+  latest|38) UBUNTU_VERSION="resolute" ;;
+  36|37)     UBUNTU_VERSION="noble"    ;;
+  *)         UBUNTU_VERSION="resolute" ;;
+esac
 
 # "latest" uses no suffix so all names are unqualified (e.g. "maas", "maas-ctrl").
 # All other instances append "-<MAAS_INSTANCE>" to avoid conflicts.

--- a/profiles/maas-region-profile.yml
+++ b/profiles/maas-region-profile.yml
@@ -1,3 +1,15 @@
+# Reference template for the MAAS development LXD profile.
+# This file is NOT used by setup-dev-env.sh (the profile is generated inline there).
+# It is provided for manual use, e.g.:
+#   lxc profile create maas-<INSTANCE>
+#   lxc profile edit maas-<INSTANCE> < profiles/maas-region-profile.yml
+#
+# Replace all REPLACE_WITH_* placeholders before applying:
+#   REPLACE_WITH_YOUR_UID   -> output of: id -u
+#   REPLACE_WITH_YOUR_GID   -> output of: id -g
+#   REPLACE_WITH_SSH_KEY    -> your public SSH key (e.g. contents of ~/.ssh/id_rsa.pub)
+#   REPLACE_WITH_MAAS_SOURCE -> absolute path to your MAAS source checkout
+#   REPLACE_WITH_INSTANCE   -> the MAAS_INSTANCE value from config.sh (e.g. "36", "dev")
 config:
     raw.idmap: |
         REPLACE_WITH_YOUR_UID
@@ -21,4 +33,16 @@ devices:
     eth0:
         type: nic
         name: eth0
-        network: maas-ctrl
+        network: maas-ctrl-REPLACE_WITH_INSTANCE
+    eth1:
+        type: nic
+        name: eth1
+        network: maas-kvm-REPLACE_WITH_INSTANCE
+    eth2:
+        type: nic
+        name: eth2
+        network: maas-ip6-REPLACE_WITH_INSTANCE
+    eth3:
+        type: nic
+        name: eth3
+        network: maas-ds-REPLACE_WITH_INSTANCE

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -309,14 +309,15 @@ configure_container() {
   echo "################################################################"
   echo "SSHing into ${MAAS_CONTAINER_NAME} (${container_ip}) development and setting it up"
   # could pass vars in there with ssh ubuntu@${container_ip} 'bash -s' < setup-region-via-ssh.sh var1 var2 ...
-  ssh -o "StrictHostKeyChecking no" ubuntu@${container_ip}\
-      MAAS_INSTANCE=${MAAS_INSTANCE}\
-      MAAS_CONTROL_IP_RANGE=${MAAS_CONTROL_IP_RANGE}\
-      MAAS_MANAGEMENT_IP_RANGE=${MAAS_MANAGEMENT_IP_RANGE}\
-      MAAS_IPV6_IP_RANGE=${MAAS_IPV6_IP_RANGE}\
-      MAAS_DUAL_STACK_IPV4_RANGE=${MAAS_DUAL_STACK_IPV4_RANGE}\
-      MAAS_DUAL_STACK_IPV6_RANGE=${MAAS_DUAL_STACK_IPV6_RANGE}\
-      bash -s < setup-region-via-ssh.bash
+  ssh -o "StrictHostKeyChecking no" ubuntu@${container_ip} \
+    MAAS_INSTANCE=${MAAS_INSTANCE} \
+    MAAS_TEST_DB_CHANNEL=${MAAS_TEST_DB_CHANNEL} \
+    MAAS_CONTROL_IP_RANGE=${MAAS_CONTROL_IP_RANGE} \
+    MAAS_MANAGEMENT_IP_RANGE=${MAAS_MANAGEMENT_IP_RANGE} \
+    MAAS_IPV6_IP_RANGE=${MAAS_IPV6_IP_RANGE} \
+    MAAS_DUAL_STACK_IPV4_RANGE=${MAAS_DUAL_STACK_IPV4_RANGE} \
+    MAAS_DUAL_STACK_IPV6_RANGE=${MAAS_DUAL_STACK_IPV6_RANGE} \
+    bash -s <setup-region-via-ssh.bash
 }
 
 add_ca_crt(){
@@ -330,15 +331,16 @@ add_ca_crt(){
   echo "Copying CA crt file into container and adding it as a trusted CA"
   base_filename=$(basename $crt_file)
   lxc file push $crt_file $MAAS_CONTAINER_NAME/usr/local/share/ca-certificates/$base_filename
-  ssh -o "StrictHostKeyChecking no" ubuntu@${container_ip}\
-      MAAS_INSTANCE=${MAAS_INSTANCE}\
-      MAAS_CONTROL_IP_RANGE=${MAAS_CONTROL_IP_RANGE}\
-      MAAS_MANAGEMENT_IP_RANGE=${MAAS_MANAGEMENT_IP_RANGE}\
-      MAAS_IPV6_IP_RANGE=${MAAS_IPV6_IP_RANGE}\
-      MAAS_DUAL_STACK_IPV4_RANGE=${MAAS_DUAL_STACK_IPV4_RANGE}\
-      MAAS_DUAL_STACK_IPV6_RANGE=${MAAS_DUAL_STACK_IPV6_RANGE}\
-      base_filename=${base_filename}\
-      bash -s < add-ca-cert.bash $base_filename
+  ssh -o "StrictHostKeyChecking no" ubuntu@${container_ip} \
+    MAAS_INSTANCE=${MAAS_INSTANCE} \
+    MAAS_TEST_DB_CHANNEL=${MAAS_TEST_DB_CHANNEL} \
+    MAAS_CONTROL_IP_RANGE=${MAAS_CONTROL_IP_RANGE} \
+    MAAS_MANAGEMENT_IP_RANGE=${MAAS_MANAGEMENT_IP_RANGE} \
+    MAAS_IPV6_IP_RANGE=${MAAS_IPV6_IP_RANGE} \
+    MAAS_DUAL_STACK_IPV4_RANGE=${MAAS_DUAL_STACK_IPV4_RANGE} \
+    MAAS_DUAL_STACK_IPV6_RANGE=${MAAS_DUAL_STACK_IPV6_RANGE} \
+    base_filename=${base_filename} \
+    bash -s $base_filename <add-ca-cert.bash
 }
 
 run() {

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -10,9 +10,9 @@ set -e
 # source config and setup variables
 . ./config.sh
 
-# Validate MAAS_INSTANCE: max 5 chars, required for kernel bridge name limit (15 chars)
+# Validate MAAS_INSTANCE: max 5 digits, required for kernel bridge name limit (15 chars).
 if [ ${#MAAS_INSTANCE} -gt 5 ]; then
-  echo "ERROR: MAAS_INSTANCE must be at most 5 characters (got: '${MAAS_INSTANCE}')."
+  echo "ERROR: MAAS_INSTANCE must be at most 5 digits (got: '${MAAS_INSTANCE}')."
   echo "  Kernel bridge names are limited to 15 chars; 'maas-ctrl-' occupies 10 of them."
   exit 1
 fi

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -10,6 +10,13 @@ set -e
 # source config and setup variables
 . ./config.sh
 
+# Validate MAAS_INSTANCE: max 5 chars, required for kernel bridge name limit (15 chars)
+if [ ${#MAAS_INSTANCE} -gt 5 ]; then
+  echo "ERROR: MAAS_INSTANCE must be at most 5 characters (got: '${MAAS_INSTANCE}')."
+  echo "  Kernel bridge names are limited to 15 chars; 'maas-ctrl-' occupies 10 of them."
+  exit 1
+fi
+
 # get absolute path for lxd
 maas_src=$(readlink -f ${MAAS_SRC})
 # see https://stackoverflow.com/questions/29832037/how-to-get-script-directory-in-posix-sh
@@ -127,17 +134,20 @@ setup_lxd() {
   echo "Setting up LXD networks"
   cd ${script_dir}
 
-  lxc network create maas-ctrl
-  cat << __EOF | lxc network edit maas-ctrl
+  if lxc network show ${MAAS_CTRL_NETWORK} >/dev/null 2>&1; then
+    echo "Network ${MAAS_CTRL_NETWORK} already exists, skipping."
+  else
+    lxc network create ${MAAS_CTRL_NETWORK}
+    cat << __EOF | lxc network edit ${MAAS_CTRL_NETWORK}
 config:
-  dns.domain: maas-ctrl
+  dns.domain: ${MAAS_CTRL_NETWORK}
   ipv4.address: ${MAAS_CONTROL_IP_RANGE}/24
   ipv4.dhcp: "true"
   ipv4.dhcp.ranges: ${control_network_prefix}.16-${control_network_prefix}.31
   ipv4.nat: "true"
   ipv6.address: none
 description: ""
-name: maas-ctrl
+name: ${MAAS_CTRL_NETWORK}
 type: bridge
 used_by: []
 managed: true
@@ -145,16 +155,20 @@ status: Created
 locations:
 - none
 __EOF
+  fi
 
-  lxc network create maas-kvm
-  cat << __EOF | lxc network edit maas-kvm
+  if lxc network show ${MAAS_KVM_NETWORK} >/dev/null 2>&1; then
+    echo "Network ${MAAS_KVM_NETWORK} already exists, skipping."
+  else
+    lxc network create ${MAAS_KVM_NETWORK}
+    cat << __EOF | lxc network edit ${MAAS_KVM_NETWORK}
 config:
   ipv4.address: ${MAAS_MANAGEMENT_IP_RANGE}/24
   ipv4.dhcp: "false"
   ipv4.nat: "true"
   ipv6.address: none
 description: ""
-name: maas-kvm
+name: ${MAAS_KVM_NETWORK}
 type: bridge
 used_by: []
 managed: true
@@ -162,16 +176,20 @@ status: Created
 locations:
 - none
 __EOF
+  fi
 
-  lxc network create maas-ipv6
-  cat << __EOF | lxc network edit maas-ipv6
+  if lxc network show ${MAAS_IPV6_NETWORK} >/dev/null 2>&1; then
+    echo "Network ${MAAS_IPV6_NETWORK} already exists, skipping."
+  else
+    lxc network create ${MAAS_IPV6_NETWORK}
+    cat << __EOF | lxc network edit ${MAAS_IPV6_NETWORK}
 config:
   ipv4.address: none
   ipv6.address: ${MAAS_IPV6_IP_RANGE}/64
   ipv6.dhcp: "false"
   ipv6.nat: "true"
 description: "An IPv6 only network"
-name: maas-ipv6
+name: ${MAAS_IPV6_NETWORK}
 type: bridge
 used_by: []
 managed: true
@@ -179,9 +197,13 @@ status: Created
 locations:
 - none
 __EOF
+  fi
 
-  lxc network create maas-dual-stack
-  cat << __EOF | lxc network edit maas-dual-stack
+  if lxc network show ${MAAS_DUAL_STACK_NETWORK} >/dev/null 2>&1; then
+    echo "Network ${MAAS_DUAL_STACK_NETWORK} already exists, skipping."
+  else
+    lxc network create ${MAAS_DUAL_STACK_NETWORK}
+    cat << __EOF | lxc network edit ${MAAS_DUAL_STACK_NETWORK}
 config:
   ipv4.address: ${MAAS_DUAL_STACK_IPV4_RANGE}/24
   ipv4.nat: "true"
@@ -190,7 +212,7 @@ config:
   ipv6.nat: "true"
   ipv6.dhcp: "false"
 description: "A network for both IPv4 and IPv6"
-name: maas-dual-stack
+name: ${MAAS_DUAL_STACK_NETWORK}
 type: bridge
 used_by: []
 managed: true
@@ -198,19 +220,32 @@ status: Created
 locations:
 - none
 __EOF
+  fi
   echo "..done"
   echo
 
-  echo "################################"
-  echo "Setting LXD HTTPS address to 8443"
-  lxc config set core.https_address [::]:8443
+  echo "#######################################"
+  echo "Checking LXD HTTPS address configuration"
+  current_https=$(lxc config get core.https_address 2>/dev/null)
+  if [ -z "${current_https}" ]; then
+    echo "Setting LXD HTTPS address to [::]:8443"
+    lxc config set core.https_address [::]:8443
+  elif [ "${current_https}" = "[::]:8443" ]; then
+    echo "LXD HTTPS address already set to [::]:8443, skipping."
+  else
+    echo "WARNING: LXD HTTPS address is '${current_https}', not changing."
+    echo "  MAAS may not be able to reach the host LXD if this is not reachable."
+  fi
   echo "..done"
   echo
 
   echo "#######################"
   echo "Setting up LXD profiles"
-  lxc profile create ${MAAS_CONTAINER_NAME}
-  cat <<EOF | lxc profile edit ${MAAS_CONTAINER_NAME}
+  if lxc profile show ${MAAS_CONTAINER_NAME} >/dev/null 2>&1; then
+    echo "Profile ${MAAS_CONTAINER_NAME} already exists, skipping."
+  else
+    lxc profile create ${MAAS_CONTAINER_NAME}
+    cat <<EOF | lxc profile edit ${MAAS_CONTAINER_NAME}
 config:
     raw.idmap: |
         uid $(id -u) 1000
@@ -234,12 +269,21 @@ devices:
     eth0:
         type: nic
         name: eth0
-        network: maas-ctrl
+        network: ${MAAS_CTRL_NETWORK}
     eth1:
         type: nic
         name: eth1
-        network: maas-kvm
+        network: ${MAAS_KVM_NETWORK}
+    eth2:
+        type: nic
+        name: eth2
+        network: ${MAAS_IPV6_NETWORK}
+    eth3:
+        type: nic
+        name: eth3
+        network: ${MAAS_DUAL_STACK_NETWORK}
 EOF
+  fi
   echo "..done"
   echo
 }
@@ -247,9 +291,13 @@ EOF
 start_container() {
   echo "##################################################################"
   echo "Setting up MAAS development container named ${MAAS_CONTAINER_NAME}"
-  lxc launch ubuntu:${UBUNTU_VERSION} ${MAAS_CONTAINER_NAME} -p default -p ${MAAS_CONTAINER_NAME}
-  echo "..waiting for container to be ready.."
-  lxc exec ${MAAS_CONTAINER_NAME} -- cloud-init status --wait
+  if lxc info ${MAAS_CONTAINER_NAME} >/dev/null 2>&1; then
+    echo "Container ${MAAS_CONTAINER_NAME} already exists, skipping launch."
+  else
+    lxc launch ubuntu:${UBUNTU_VERSION} ${MAAS_CONTAINER_NAME} -p default -p ${MAAS_CONTAINER_NAME}
+    echo "..waiting for container to be ready.."
+    lxc exec ${MAAS_CONTAINER_NAME} -- cloud-init status --wait
+  fi
   echo "..done"
   echo
 }
@@ -261,6 +309,7 @@ configure_container() {
   echo "SSHing into ${MAAS_CONTAINER_NAME} (${container_ip}) development and setting it up"
   # could pass vars in there with ssh ubuntu@${container_ip} 'bash -s' < setup-region-via-ssh.sh var1 var2 ...
   ssh -o "StrictHostKeyChecking no" ubuntu@${container_ip}\
+      MAAS_INSTANCE=${MAAS_INSTANCE}\
       MAAS_CONTROL_IP_RANGE=${MAAS_CONTROL_IP_RANGE}\
       MAAS_MANAGEMENT_IP_RANGE=${MAAS_MANAGEMENT_IP_RANGE}\
       MAAS_IPV6_IP_RANGE=${MAAS_IPV6_IP_RANGE}\
@@ -281,6 +330,7 @@ add_ca_crt(){
   base_filename=$(basename $crt_file)
   lxc file push $crt_file $MAAS_CONTAINER_NAME/usr/local/share/ca-certificates/$base_filename
   ssh -o "StrictHostKeyChecking no" ubuntu@${container_ip}\
+      MAAS_INSTANCE=${MAAS_INSTANCE}\
       MAAS_CONTROL_IP_RANGE=${MAAS_CONTROL_IP_RANGE}\
       MAAS_MANAGEMENT_IP_RANGE=${MAAS_MANAGEMENT_IP_RANGE}\
       MAAS_IPV6_IP_RANGE=${MAAS_IPV6_IP_RANGE}\

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -10,8 +10,9 @@ set -e
 # source config and setup variables
 . ./config.sh
 
-# Validate MAAS_INSTANCE: max 5 digits, required for kernel bridge name limit (15 chars).
-if [ ${#MAAS_INSTANCE} -gt 5 ]; then
+# Validate MAAS_INSTANCE length: max 5 digits (kernel bridge name limit of 15 chars).
+# "latest" is exempt because it uses no suffix so bridge names stay short.
+if [ "${MAAS_INSTANCE}" != "latest" ] && [ ${#MAAS_INSTANCE} -gt 5 ]; then
   echo "ERROR: MAAS_INSTANCE must be at most 5 digits (got: '${MAAS_INSTANCE}')."
   echo "  Kernel bridge names are limited to 15 chars; 'maas-ctrl-' occupies 10 of them."
   exit 1

--- a/setup-region-via-ssh.bash
+++ b/setup-region-via-ssh.bash
@@ -119,7 +119,7 @@ maas admin vlan update $target_fabric_id untagged dhcp_on=True primary_rack=$tar
 echo
 echo "#############################"
 echo "Adding your hosts lxd to MAAS"
-maas admin vm-hosts create type=lxd power_address=${control_network_prefix}.1 project=maas name=maas-host
+maas admin vm-hosts create type=lxd power_address=${control_network_prefix}.1 project=maas-${MAAS_INSTANCE} name=maas-host-${MAAS_INSTANCE}
 
 echo
 echo "#################################################################"

--- a/setup-region-via-ssh.bash
+++ b/setup-region-via-ssh.bash
@@ -57,7 +57,7 @@ dpkg --list | grep nginx-core && sudo systemctl stop nginx && systemctl disable 
 echo
 echo "#################################"
 echo "Installing the MAAS test database"
-sudo snap install maas-test-db --channel=latest/edge
+sudo snap install maas-test-db --channel=${MAAS_TEST_DB_CHANNEL}
 
 echo
 echo "#######################"

--- a/setup-region-via-ssh.bash
+++ b/setup-region-via-ssh.bash
@@ -57,6 +57,8 @@ dpkg --list | grep nginx-core && sudo systemctl stop nginx && systemctl disable 
 echo
 echo "#################################"
 echo "Installing the MAAS test database"
+sudo snap install core26 --beta
+sudo snap install snapd --beta
 sudo snap install maas-test-db --channel=${MAAS_TEST_DB_CHANNEL}
 
 echo

--- a/setup-region-via-ssh.bash
+++ b/setup-region-via-ssh.bash
@@ -57,8 +57,8 @@ dpkg --list | grep nginx-core && sudo systemctl stop nginx && systemctl disable 
 echo
 echo "#################################"
 echo "Installing the MAAS test database"
-sudo snap install core26 --beta
-sudo snap install snapd --beta
+sudo snap install core26
+sudo snap install snapd
 sudo snap install maas-test-db --channel=${MAAS_TEST_DB_CHANNEL}
 
 echo
@@ -99,10 +99,10 @@ echo "Login using admin profile"
 declare -i maas_up=1
 while [ $maas_up -ne 0 ]; do
   # Check if the MAAS API is up before attempting to login
-  if curl -sf "http://${container_ip}:5240/MAAS/api/2.0/version/" > /dev/null 2>&1; then
-    maas login admin "http://${container_ip}:5240/MAAS/api/2.0/" $(sudo maas apikey --username=maas);
+  if curl -sf "http://${container_ip}:5240/MAAS/api/2.0/version/" >/dev/null 2>&1; then
+    maas login admin "http://${container_ip}:5240/MAAS/api/2.0/" $(sudo maas apikey --username=maas)
     maas_up=$?
-  else 
+  else
     echo "Retrying in 5 seconds..."
     sleep 5
   fi


### PR DESCRIPTION
Still WIP. But some comments:

- IP ranges: To isolate the network-related setup, I decided to associate the third octet to the version of MAAS. In an attempt to balance for a comfortable amount of minor versions but also major versions, the logic is to consider a version X.Y to represent a base-30 two-digit integer.  This allows us to go until something like 8.10 without issues (since the integer has to be <=255), which is more than enough for not-so-near future. Note that this assumes that we will have <30 for minor versions, which seems reasonable given our release cadence.
- Namings: This might change, but I am assuming for now that we are mainly driving things through a name derived from the version, which should be specified _without_ separation. It is a little awkward to keep major+minor together, but it prevents potential issues with dots/spaces etc in file names (I've had issues with these separations and go paths for example), and it also saves some characters (which is relevant for the network interfaces names). As long as our versions stay in the major <10 and minor <100 range, this should be fine.
  That being said, it might be worth having a special name (not a number) for "latest". Then we will have to protect an IP range separately from the above (we likely could just reuse the current one for this).